### PR TITLE
TUI: Add read-only torrent files panel (f / :files, 1s refresh)

### DIFF
--- a/dashboard/torrents.go
+++ b/dashboard/torrents.go
@@ -10,51 +10,55 @@ import (
 	"strings"
 )
 
-
 type Torrent struct {
-	Name     string `json:"name"`
-	Progress float64 `json:"progress"`
-	State    string `json:"state"`
-	Speed    int `json:"dlspeed"`
-	UpSpeed    int `json:"upspeed"`
-	ETA      int `json:"eta"`
-	Peers    int `json:"peers"`
-	Size    int `json:"size"`
-	AddedOn int `json:"added_on"`
-	Hash string `json:"hash"`
-	Seeds int `json:"num_seeds"`
-	Leech int `json:"num_leechs"`
-	Private bool `json:"private"`
-	ForceStart bool `json:"force_start"`
-	SuperSeeding bool `json:"super_seeding"`
+	Name         string  `json:"name"`
+	Progress     float64 `json:"progress"`
+	State        string  `json:"state"`
+	Speed        int     `json:"dlspeed"`
+	UpSpeed      int     `json:"upspeed"`
+	ETA          int     `json:"eta"`
+	Peers        int     `json:"peers"`
+	Size         int     `json:"size"`
+	AddedOn      int     `json:"added_on"`
+	Hash         string  `json:"hash"`
+	Seeds        int     `json:"num_seeds"`
+	Leech        int     `json:"num_leechs"`
+	Private      bool    `json:"private"`
+	ForceStart   bool    `json:"force_start"`
+	SuperSeeding bool    `json:"super_seeding"`
 }
 
+type TorrentFile struct {
+	Index    int     `json:"index"`
+	Name     string  `json:"name"`
+	Size     int     `json:"size"`
+	Progress float64 `json:"progress"`
+	Priority int     `json:"priority"`
+	IsSeed   *bool   `json:"is_seed,omitempty"`
+}
 
 type Qbit struct {
-	Url string
+	Url      string
 	Username string
 	Password string
 }
 
-
-func Logout(client *http.Client,host string) {
+func Logout(client *http.Client, host string) {
 	url := fmt.Sprintf("%s/api/v2/auth/logout", strings.TrimRight(host, "/"))
-	_, err := client.Post(url,"application/x-www-form-urlencoded", nil)
+	_, err := client.Post(url, "application/x-www-form-urlencoded", nil)
 	if err != nil {
 		fmt.Println(err)
 	}
 }
 
-
 func LoginToQbit(host, username, password string) (*http.Client, error) {
-	
 	jar, _ := cookiejar.New(nil)
 	client := &http.Client{Jar: jar}
 
 	data := url.Values{
-			"username": {username},
-			"password": {password},
-		}
+		"username": {username},
+		"password": {password},
+	}
 	resp, err := client.PostForm(host+"/api/v2/auth/login", data)
 	if err != nil {
 		return nil, err
@@ -64,12 +68,11 @@ func LoginToQbit(host, username, password string) (*http.Client, error) {
 	return client, nil
 }
 
-
 func AddMagnet(client *http.Client, host, magnet string) error {
 	addURL := fmt.Sprintf("%s/api/v2/torrents/add", strings.TrimRight(host, "/"))
 	form := url.Values{}
 	form.Set("urls", magnet)
-	values := url.Values{"urls":{magnet}}
+	values := url.Values{"urls": {magnet}}
 	resp, err := client.PostForm(addURL, values)
 	if err != nil {
 		return err
@@ -82,34 +85,48 @@ func AddMagnet(client *http.Client, host, magnet string) error {
 	return nil
 }
 
-
-
-func FetchTorrents(client *http.Client,host string) ([]Torrent ,error) {
+func FetchTorrents(client *http.Client, host string) ([]Torrent, error) {
 	url := fmt.Sprintf("%s/api/v2/torrents/info?sort=ratio", strings.TrimRight(host, "/"))
 	resp, err := client.Get(url)
-		if err != nil {
-			return nil, err
+	if err != nil {
+		return nil, err
 	}
 	defer resp.Body.Close()
 	body, _ := io.ReadAll(resp.Body)
 	var torrents []Torrent
 	err = json.Unmarshal(body, &torrents)
-	
+
 	if resp.StatusCode != 200 {
 		return []Torrent{}, fmt.Errorf("Status %d: %s", resp.StatusCode, string(body))
 	}
-	return torrents,nil
-		
+	return torrents, nil
 }
 
+func FetchTorrentFiles(client *http.Client, host, hash string) ([]TorrentFile, error) {
+	url := fmt.Sprintf("%s/api/v2/torrents/files?hash=%s", strings.TrimRight(host, "/"), hash)
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return []TorrentFile{}, fmt.Errorf("Status %d: %s", resp.StatusCode, string(body))
+	}
+	var files []TorrentFile
+	if err := json.Unmarshal(body, &files); err != nil {
+		return nil, err
+	}
+	return files, nil
+}
 
-func PostTorrentAction(client *http.Client,host, endpoint string, params url.Values) error {
+func PostTorrentAction(client *http.Client, host, endpoint string, params url.Values) error {
 	url := fmt.Sprintf("%s/api/v2/torrents/%s", strings.TrimRight(host, "/"), endpoint)
-	resp, err := client.Post(url,"application/x-www-form-urlencoded", strings.NewReader(params.Encode()))
+	resp, err := client.Post(url, "application/x-www-form-urlencoded", strings.NewReader(params.Encode()))
 	if err != nil {
 		return err
 	}
-	
+
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		body, _ := io.ReadAll(resp.Body)

--- a/dashboard/utils.go
+++ b/dashboard/utils.go
@@ -11,6 +11,7 @@ func formatSpeed(bytes int) string {
 	}
 	return fmt.Sprintf("%.1f KB/s", float64(bytes)/1024)
 }
+
 func TruncateName(name string, max int) string {
 	if len(name) <= max {
 		return name
@@ -21,6 +22,9 @@ func TruncateName(name string, max int) string {
 	return name[:max-3] + "..."
 }
 
+func FormatPercent(p float64) string {
+	return fmt.Sprintf("%.2f%%", p*100)
+}
 
 func formatETA(seconds int) string {
 	if seconds < 0 || seconds == 8640000 {
@@ -34,7 +38,6 @@ func formatETA(seconds int) string {
 	}
 	return fmt.Sprintf("%dm", m)
 }
-
 
 func FormatAddedOn(ts int) string {
 	if ts == 0 {
@@ -56,4 +59,14 @@ func FormatSize(size int) string {
 	default:
 		return fmt.Sprintf("%d B", size)
 	}
+}
+
+func FormatBoolPtr(b *bool) string {
+	if b == nil {
+		return "—"
+	}
+	if *b {
+		return "true"
+	}
+	return "false"
 }


### PR DESCRIPTION
This PR adds a read-only file list view for the currently selected torrent in the TUI.\n\nScope & behavior:\n- Press  or run  to open a modal/panel listing files of the selected torrent;  closes it.\n- Columns: Index, Name, Size, Progress, Priority, Seed flag (if available).\n- Refreshes every 1s while open; follows paginator/selection changes.\n- Status line surfaces the last action/result and API errors.\n\nImplementation details:\n- dashboard/torrents.go — Added TorrentFile and FetchTorrentFiles(client, host, hash).\n- dashboard/utils.go — Added FormatPercent and FormatBoolPtr; reused existing FormatSize/TruncateName.\n- dashboard/dash.go — Panel state, rendering (header shows torrent name + short hash), key/command bindings, and 1s refresh loop (fileTick).\n\nAcceptance notes:\n- Selecting a torrent and pressing  shows its files with accurate names/sizes/progress and updates over time.\n- Closing with  returns to the main list; no crashes when switching selection/pages while open.\n\nFuture follow-ups (out of scope): sorting by columns, interactive priority changes, and column width customization.